### PR TITLE
Add Node POJO unit tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CheatsheetGraph
+
+## Code Conventions
+
+### Method Comments
+Always write a single-line `//` comment directly above every method that describes its function.
+
+Example:
+```java
+// Verifies reflexivity: a node is always equal to itself
+@Test
+void equalsShouldReturnTrueForSameInstance() {
+    ...
+}
+```

--- a/src/test/java/com/aditya/java/pojo/NodeTest.java
+++ b/src/test/java/com/aditya/java/pojo/NodeTest.java
@@ -1,0 +1,83 @@
+package com.aditya.java.pojo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NodeTest {
+
+    @Test
+    void equalsShouldReturnTrueForSameInstance() {
+        Node<String> node = new Node<>("A");
+        assertEquals(node, node);
+    }
+
+    @Test
+    void equalsShouldReturnTrueForEqualNodes() {
+        Node<String> node1 = new Node<>("A");
+        node1.connectedNodes.add(new Node<>("B"));
+
+        Node<String> node2 = new Node<>("A");
+        node2.connectedNodes.add(new Node<>("B"));
+
+        assertEquals(node1, node2);
+    }
+
+    @Test
+    void equalsShouldReturnFalseForDifferentData() {
+        Node<String> node1 = new Node<>("A");
+        Node<String> node2 = new Node<>("B");
+        assertNotEquals(node1, node2);
+    }
+
+    @Test
+    void equalsShouldReturnFalseForDifferentConnections() {
+        Node<String> node1 = new Node<>("A");
+        node1.connectedNodes.add(new Node<>("B"));
+
+        Node<String> node2 = new Node<>("A");
+        node2.connectedNodes.add(new Node<>("C"));
+
+        assertNotEquals(node1, node2);
+    }
+
+    @Test
+    void equalsShouldReturnFalseForNull() {
+        Node<String> node = new Node<>("A");
+        assertFalse(node.equals(null));
+    }
+
+    @Test
+    void equalsShouldReturnFalseForDifferentClass() {
+        Node<String> node = new Node<>("A");
+        assertFalse(node.equals("A"));
+    }
+
+    @Test
+    void hashCodeShouldBeEqualForEqualNodes() {
+        Node<String> node1 = new Node<>("A");
+        node1.connectedNodes.add(new Node<>("B"));
+
+        Node<String> node2 = new Node<>("A");
+        node2.connectedNodes.add(new Node<>("B"));
+
+        assertEquals(node1.hashCode(), node2.hashCode());
+    }
+
+    @Test
+    void toStringShouldContainDataAndConnections() {
+        Node<String> node = new Node<>("A");
+        node.connectedNodes.add(new Node<>("B"));
+
+        String result = node.toString();
+        assertTrue(result.contains("A"));
+        assertTrue(result.contains("B"));
+    }
+
+    @Test
+    void getDataShouldReturnCorrectValue() {
+        Node<Integer> node = new Node<>(42);
+        assertEquals(42, node.getData());
+    }
+
+}

--- a/src/test/java/com/aditya/java/pojo/NodeTest.java
+++ b/src/test/java/com/aditya/java/pojo/NodeTest.java
@@ -6,12 +6,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class NodeTest {
 
+    // Verifies reflexivity: a node is always equal to itself
     @Test
     void equalsShouldReturnTrueForSameInstance() {
         Node<String> node = new Node<>("A");
         assertEquals(node, node);
     }
 
+    // Verifies structural equality: two nodes with the same data and neighbour data are equal
     @Test
     void equalsShouldReturnTrueForEqualNodes() {
         Node<String> node1 = new Node<>("A");
@@ -23,6 +25,7 @@ public class NodeTest {
         assertEquals(node1, node2);
     }
 
+    // Verifies that nodes with different data values are not equal
     @Test
     void equalsShouldReturnFalseForDifferentData() {
         Node<String> node1 = new Node<>("A");
@@ -30,6 +33,7 @@ public class NodeTest {
         assertNotEquals(node1, node2);
     }
 
+    // Verifies that nodes with the same data but different neighbours are not equal
     @Test
     void equalsShouldReturnFalseForDifferentConnections() {
         Node<String> node1 = new Node<>("A");
@@ -41,18 +45,21 @@ public class NodeTest {
         assertNotEquals(node1, node2);
     }
 
+    // Verifies null-safety: equals returns false when compared to null
     @Test
     void equalsShouldReturnFalseForNull() {
         Node<String> node = new Node<>("A");
         assertFalse(node.equals(null));
     }
 
+    // Verifies type-safety: equals returns false when compared to a different class
     @Test
     void equalsShouldReturnFalseForDifferentClass() {
         Node<String> node = new Node<>("A");
         assertFalse(node.equals("A"));
     }
 
+    // Verifies the hashCode contract: equal nodes must produce the same hash code
     @Test
     void hashCodeShouldBeEqualForEqualNodes() {
         Node<String> node1 = new Node<>("A");
@@ -64,6 +71,7 @@ public class NodeTest {
         assertEquals(node1.hashCode(), node2.hashCode());
     }
 
+    // Verifies that toString output includes both the node's data and its neighbour data
     @Test
     void toStringShouldContainDataAndConnections() {
         Node<String> node = new Node<>("A");
@@ -74,6 +82,7 @@ public class NodeTest {
         assertTrue(result.contains("B"));
     }
 
+    // Verifies getData() returns the correct value; also exercises Node<Integer> to validate generics
     @Test
     void getDataShouldReturnCorrectValue() {
         Node<Integer> node = new Node<>(42);


### PR DESCRIPTION
## Summary
- Add `NodeTest.java` (9 tests) covering `equals`, `hashCode`, `toString`, and `getData`
- Exercises `Node<Integer>` to validate generic type support
- The `Node` POJO previously had zero test coverage despite custom `equals`/`hashCode`

## Test plan
- [x] Run `mvn test` — all 9 new tests in `NodeTest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)