### PR TITLE
Add GraphUtil edge-case tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CheatsheetGraph
+
+## Code Conventions
+
+### Method Comments
+Always write a single-line `//` comment directly above every method that describes its function.
+
+Example:
+```java
+// Verifies reflexivity: a node is always equal to itself
+@Test
+void equalsShouldReturnTrueForSameInstance() {
+    ...
+}
+```

--- a/src/test/java/com/aditya/java/util/GraphUtilTest.java
+++ b/src/test/java/com/aditya/java/util/GraphUtilTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class GraphUtilTest {
 
+    // Verifies a manually-built 4-node cycle graph is correctly serialized to an adjacency map
     @Test
     void convertGraphToMapShouldCreateMapCorrectly() {
 
@@ -28,6 +29,7 @@ public class GraphUtilTest {
         assertEquals(expectedMap, mapOfGraph);
     }
 
+    // Verifies that converting a map to a graph and back produces the same adjacency map
     @Test
     void convertMapToGraphShouldCreateGraphCorrectly() {
 
@@ -67,6 +69,7 @@ public class GraphUtilTest {
         return nodeA;
     }
 
+    // Verifies that connected node objects are correctly mapped to a set of their data values
     @Test
     void convertConnectedNodesToSetOfDataShouldReturnSetOfDataInConnectedNodes(){
         Node<String> nodeA = new Node<>("A");
@@ -77,6 +80,7 @@ public class GraphUtilTest {
         assertEquals(Set.of("B","C"), GraphUtil.convertConnectedNodesToSetOfData(nodeA));
     }
 
+    // Verifies that an empty map input returns null
     @Test
     void convertMapToGraphShouldReturnNullForEmptyMap() {
         Map<String, Set<String>> emptyMap = new HashMap<>();
@@ -84,6 +88,7 @@ public class GraphUtilTest {
         assertNull(result);
     }
 
+    // Verifies the single-node special case: a map with one isolated entry is handled without throwing
     @Test
     void convertMapToGraphShouldHandleSingleIsolatedNode() {
         Node<String> result = GraphUtil.convertMapToGraph(Map.of("A", Set.of()));
@@ -92,6 +97,7 @@ public class GraphUtilTest {
         assertTrue(result.connectedNodes.isEmpty());
     }
 
+    // Verifies that a disconnected node in a multi-node graph throws IllegalArgumentException
     @Test
     void convertMapToGraphShouldThrowForDisconnectedNode() {
         Map<String, Set<String>> map = Map.ofEntries(
@@ -102,6 +108,7 @@ public class GraphUtilTest {
         assertThrows(IllegalArgumentException.class, () -> GraphUtil.convertMapToGraph(map));
     }
 
+    // Verifies that a neighbour referenced in values but absent as a key is created with no connections
     @Test
     void convertMapToGraphShouldHandleNodeReferencedButMissingAsKey() {
         Map<String, Set<String>> map = Map.of("A", Set.of("B"));
@@ -114,6 +121,7 @@ public class GraphUtilTest {
         assertTrue(bNode.connectedNodes.isEmpty());
     }
 
+    // Verifies that a lone node with no connections converts to a map entry with an empty set
     @Test
     void convertGraphToMapShouldHandleSingleNode() {
         Node<String> node = new Node<>("A");
@@ -121,12 +129,14 @@ public class GraphUtilTest {
         assertEquals(Map.of("A", Set.of()), result);
     }
 
+    // Verifies that a node with no neighbours returns an empty set
     @Test
     void convertConnectedNodesToSetOfDataShouldReturnEmptySetForIsolatedNode() {
         Node<String> node = new Node<>("A");
         assertEquals(Set.of(), GraphUtil.convertConnectedNodesToSetOfData(node));
     }
 
+    // Verifies the round-trip map->graph->map works for Integer-typed nodes, exercising generics
     @Test
     void convertMapToGraphShouldWorkWithIntegerNodes() {
         Map<Integer, Set<Integer>> map = Map.ofEntries(

--- a/src/test/java/com/aditya/java/util/GraphUtilTest.java
+++ b/src/test/java/com/aditya/java/util/GraphUtilTest.java
@@ -1,0 +1,144 @@
+package com.aditya.java.util;
+
+
+import com.aditya.java.pojo.Node;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GraphUtilTest {
+
+    @Test
+    void convertGraphToMapShouldCreateMapCorrectly() {
+
+        Map<String, Set<String>> expectedMap = Map.ofEntries(
+                Map.entry("A", Set.of("B", "C")),
+                Map.entry("B", Set.of("A", "D")),
+                Map.entry("C", Set.of("A", "D")),
+                Map.entry("D", Set.of("B", "C"))
+        );
+
+        Node<String> nodeA = createBasicGraphManually();
+        Map<String, Set<String>> mapOfGraph = GraphUtil.convertGraphToMap(nodeA);
+
+        assertEquals(expectedMap, mapOfGraph);
+    }
+
+    @Test
+    void convertMapToGraphShouldCreateGraphCorrectly() {
+
+        Node<String> nodeA = createBasicGraphManually();
+        Map<String, Set<String>> mapOfManuallyCreatedGraph = GraphUtil.convertGraphToMap(nodeA);
+
+        Map<String, Set<String>> toConvertToGraph = Map.ofEntries(
+                Map.entry("A", Set.of("B", "C")),
+                Map.entry("B", Set.of("A", "D")),
+                Map.entry("C", Set.of("A", "D")),
+                Map.entry("D", Set.of("B", "C"))
+        );
+        Map<String, Set<String>> mapOfGraphOfMap = GraphUtil.convertGraphToMap(
+                GraphUtil.convertMapToGraph(toConvertToGraph));
+
+        assertEquals(mapOfManuallyCreatedGraph, mapOfGraphOfMap);
+
+    }
+
+    private static Node<String> createBasicGraphManually() {
+        // A - B
+        // |   |
+        // C - D
+
+        Node<String> nodeA = new Node<>("A");
+        Node<String> nodeB = new Node<>("B");
+        Node<String> nodeC = new Node<>("C");
+        Node<String> nodeD = new Node<>("D");
+        nodeA.connectedNodes.add(nodeB);
+        nodeA.connectedNodes.add(nodeC);
+        nodeB.connectedNodes.add(nodeA);
+        nodeB.connectedNodes.add(nodeD);
+        nodeC.connectedNodes.add(nodeA);
+        nodeC.connectedNodes.add(nodeD);
+        nodeD.connectedNodes.add(nodeB);
+        nodeD.connectedNodes.add(nodeC);
+        return nodeA;
+    }
+
+    @Test
+    void convertConnectedNodesToSetOfDataShouldReturnSetOfDataInConnectedNodes(){
+        Node<String> nodeA = new Node<>("A");
+        Node<String> nodeB = new Node<>("B");
+        Node<String> nodeC = new Node<>("C");
+        nodeA.connectedNodes.add(nodeB);
+        nodeA.connectedNodes.add(nodeC);
+        assertEquals(Set.of("B","C"), GraphUtil.convertConnectedNodesToSetOfData(nodeA));
+    }
+
+    @Test
+    void convertMapToGraphShouldReturnNullForEmptyMap() {
+        Map<String, Set<String>> emptyMap = new HashMap<>();
+        Node<String> result = GraphUtil.convertMapToGraph(emptyMap);
+        assertNull(result);
+    }
+
+    @Test
+    void convertMapToGraphShouldHandleSingleIsolatedNode() {
+        Node<String> result = GraphUtil.convertMapToGraph(Map.of("A", Set.of()));
+        assertNotNull(result);
+        assertEquals("A", result.getData());
+        assertTrue(result.connectedNodes.isEmpty());
+    }
+
+    @Test
+    void convertMapToGraphShouldThrowForDisconnectedNode() {
+        Map<String, Set<String>> map = Map.ofEntries(
+                Map.entry("A", Set.of("B")),
+                Map.entry("B", Set.of("A")),
+                Map.entry("C", Set.of())
+        );
+        assertThrows(IllegalArgumentException.class, () -> GraphUtil.convertMapToGraph(map));
+    }
+
+    @Test
+    void convertMapToGraphShouldHandleNodeReferencedButMissingAsKey() {
+        Map<String, Set<String>> map = Map.of("A", Set.of("B"));
+        Node<String> result = GraphUtil.convertMapToGraph(map);
+
+        assertEquals("A", result.getData());
+        assertEquals(1, result.connectedNodes.size());
+        Node<String> bNode = result.connectedNodes.iterator().next();
+        assertEquals("B", bNode.getData());
+        assertTrue(bNode.connectedNodes.isEmpty());
+    }
+
+    @Test
+    void convertGraphToMapShouldHandleSingleNode() {
+        Node<String> node = new Node<>("A");
+        Map<String, Set<String>> result = GraphUtil.convertGraphToMap(node);
+        assertEquals(Map.of("A", Set.of()), result);
+    }
+
+    @Test
+    void convertConnectedNodesToSetOfDataShouldReturnEmptySetForIsolatedNode() {
+        Node<String> node = new Node<>("A");
+        assertEquals(Set.of(), GraphUtil.convertConnectedNodesToSetOfData(node));
+    }
+
+    @Test
+    void convertMapToGraphShouldWorkWithIntegerNodes() {
+        Map<Integer, Set<Integer>> map = Map.ofEntries(
+                Map.entry(1, Set.of(2)),
+                Map.entry(2, Set.of(1))
+        );
+        Map<Integer, Set<Integer>> expected = Map.ofEntries(
+                Map.entry(1, Set.of(2)),
+                Map.entry(2, Set.of(1))
+        );
+        assertEquals(expected, GraphUtil.convertGraphToMap(GraphUtil.convertMapToGraph(map)));
+    }
+
+
+}


### PR DESCRIPTION
## Summary
- Add 7 tests to `GraphUtilTest` covering previously untested code paths
- Empty map returns `null` (line 13 of `GraphUtil`)
- Single isolated node (`map.size()==1` special-case branch, line 16)
- `IllegalArgumentException` for disconnected nodes (exception path, lines 17-18)
- Node referenced in values but absent as a map key
- `convertGraphToMap` with a single node
- `convertConnectedNodesToSetOfData` returns empty set for an isolated node
- Round-trip with `Integer` generic type

## Test plan
- [x] Run `mvn test` — all 10 tests in `GraphUtilTest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)