### PR TITLE
Add BFS and DFS traversal tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CheatsheetGraph
+
+## Code Conventions
+
+### Method Comments
+Always write a single-line `//` comment directly above every method that describes its function.
+
+Example:
+```java
+// Verifies reflexivity: a node is always equal to itself
+@Test
+void equalsShouldReturnTrueForSameInstance() {
+    ...
+}
+```

--- a/src/test/java/com/aditya/java/BFSGraphTest.java
+++ b/src/test/java/com/aditya/java/BFSGraphTest.java
@@ -1,0 +1,94 @@
+package com.aditya.java;
+
+import com.aditya.java.BFSGraph;
+import com.aditya.java.util.GraphUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+public class BFSGraphTest {
+
+    @Test
+    void iterativeBFSShouldReturnCorrectBFSOrder(){
+        // A - B
+        // |   |
+        // C - D
+
+        Map<String, Set<String>> toConvertToGraph = Map.ofEntries(
+                Map.entry("A", Set.of("B", "C")),
+                Map.entry("B", Set.of("A", "D")),
+                Map.entry("C", Set.of("A", "D")),
+                Map.entry("D", Set.of("B", "C"))
+        );
+
+        List<String> bfs = BFSGraph.iterativeBFS(GraphUtil.convertMapToGraph(toConvertToGraph));
+        assertThat(bfs, anyOf(
+                is(List.of("D", "C", "B", "A")),
+                is(List.of("D", "B", "C", "A")),
+                is(List.of("A", "B", "C", "D")),
+                is(List.of("A", "C", "B", "D")),
+                is(List.of("C", "A", "D", "B")),
+                is(List.of("C", "D", "A", "B")),
+                is(List.of("B", "D", "A", "C")),
+                is(List.of("B", "D", "A", "C"))
+                ));
+    }
+
+    @Test
+    void iterativeBFSShouldReturnSingleElementForSingleNodeGraph() {
+        List<String> result = BFSGraph.iterativeBFS(GraphUtil.convertMapToGraph(Map.of("A", Set.of())));
+        assertThat(result, is(List.of("A")));
+    }
+
+    @Test
+    void iterativeBFSShouldTraverseLinearChain() {
+        // A - B - C
+        Map<String, Set<String>> map = Map.ofEntries(
+                Map.entry("A", Set.of("B")),
+                Map.entry("B", Set.of("A", "C")),
+                Map.entry("C", Set.of("B"))
+        );
+        List<String> result = BFSGraph.iterativeBFS(GraphUtil.convertMapToGraph(map));
+        assertThat(result, anyOf(
+                is(List.of("A", "B", "C")),
+                is(List.of("B", "A", "C")),
+                is(List.of("B", "C", "A")),
+                is(List.of("C", "B", "A"))
+        ));
+    }
+
+    @Test
+    void iterativeBFSShouldTraverseTreeGraph() {
+        //     R
+        //    / \
+        //   A   B
+        //  / \
+        // C   D
+        Map<String, Set<String>> map = Map.ofEntries(
+                Map.entry("R", Set.of("A", "B")),
+                Map.entry("A", Set.of("R", "C", "D")),
+                Map.entry("B", Set.of("R")),
+                Map.entry("C", Set.of("A")),
+                Map.entry("D", Set.of("A"))
+        );
+        List<String> result = BFSGraph.iterativeBFS(GraphUtil.convertMapToGraph(map));
+        assertThat(result, containsInAnyOrder("R", "A", "B", "C", "D"));
+    }
+
+    @Test
+    void iterativeBFSShouldWorkWithIntegerNodes() {
+        Map<Integer, Set<Integer>> map = Map.ofEntries(
+                Map.entry(1, Set.of(2)),
+                Map.entry(2, Set.of(1))
+        );
+        List<Integer> result = BFSGraph.iterativeBFS(GraphUtil.convertMapToGraph(map));
+        assertThat(result, anyOf(is(List.of(1, 2)), is(List.of(2, 1))));
+    }
+
+}

--- a/src/test/java/com/aditya/java/BFSGraphTest.java
+++ b/src/test/java/com/aditya/java/BFSGraphTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class BFSGraphTest {
 
+    // Verifies BFS order on a 4-node cycle; uses anyOf to account for nondeterministic Set iteration
     @Test
     void iterativeBFSShouldReturnCorrectBFSOrder(){
         // A - B
@@ -40,12 +41,14 @@ public class BFSGraphTest {
                 ));
     }
 
+    // Verifies BFS on a single isolated node returns a one-element list
     @Test
     void iterativeBFSShouldReturnSingleElementForSingleNodeGraph() {
         List<String> result = BFSGraph.iterativeBFS(GraphUtil.convertMapToGraph(Map.of("A", Set.of())));
         assertThat(result, is(List.of("A")));
     }
 
+    // Verifies BFS traverses a 3-node linear chain visiting each node exactly once
     @Test
     void iterativeBFSShouldTraverseLinearChain() {
         // A - B - C
@@ -63,6 +66,7 @@ public class BFSGraphTest {
         ));
     }
 
+    // Verifies BFS visits all nodes of a tree graph regardless of start node or iteration order
     @Test
     void iterativeBFSShouldTraverseTreeGraph() {
         //     R
@@ -81,6 +85,7 @@ public class BFSGraphTest {
         assertThat(result, containsInAnyOrder("R", "A", "B", "C", "D"));
     }
 
+    // Verifies BFS works with Integer-typed nodes, exercising the generic Node<T> parameter
     @Test
     void iterativeBFSShouldWorkWithIntegerNodes() {
         Map<Integer, Set<Integer>> map = Map.ofEntries(

--- a/src/test/java/com/aditya/java/DFSGraphTest.java
+++ b/src/test/java/com/aditya/java/DFSGraphTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class DFSGraphTest {
 
+    // Verifies DFS order on a 4-node cycle; uses anyOf to account for nondeterministic Set iteration
     @Test
     void iterativeDFSShouldReturnCorrectDFSOrder(){
         // A - B
@@ -39,12 +40,14 @@ public class DFSGraphTest {
         ));
     }
 
+    // Verifies DFS on a single isolated node returns a one-element list
     @Test
     void iterativeDFSShouldReturnSingleElementForSingleNodeGraph() {
         List<String> result = DFSGraph.iterativeDFS(GraphUtil.convertMapToGraph(Map.of("A", Set.of())));
         assertThat(result, is(List.of("A")));
     }
 
+    // Verifies DFS traverses a 3-node linear chain visiting each node exactly once
     @Test
     void iterativeDFSShouldTraverseLinearChain() {
         // A - B - C
@@ -62,6 +65,7 @@ public class DFSGraphTest {
         ));
     }
 
+    // Verifies DFS visits all nodes of a tree graph regardless of start node or iteration order
     @Test
     void iterativeDFSShouldTraverseTreeGraph() {
         //     R
@@ -80,6 +84,7 @@ public class DFSGraphTest {
         assertThat(result, containsInAnyOrder("R", "A", "B", "C", "D"));
     }
 
+    // Verifies DFS works with Integer-typed nodes, exercising the generic Node<T> parameter
     @Test
     void iterativeDFSShouldWorkWithIntegerNodes() {
         Map<Integer, Set<Integer>> map = Map.ofEntries(

--- a/src/test/java/com/aditya/java/DFSGraphTest.java
+++ b/src/test/java/com/aditya/java/DFSGraphTest.java
@@ -1,0 +1,93 @@
+package com.aditya.java;
+
+import com.aditya.java.util.GraphUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+public class DFSGraphTest {
+
+    @Test
+    void iterativeDFSShouldReturnCorrectDFSOrder(){
+        // A - B
+        // |   |
+        // C - D
+
+        Map<String, Set<String>> toConvertToGraph = Map.ofEntries(
+                Map.entry("A", Set.of("B", "C")),
+                Map.entry("B", Set.of("A", "D")),
+                Map.entry("C", Set.of("A", "D")),
+                Map.entry("D", Set.of("B", "C"))
+        );
+
+        List<String> dfs = DFSGraph.iterativeDFS(GraphUtil.convertMapToGraph(toConvertToGraph));
+        assertThat(dfs, anyOf(
+                is(List.of("A", "B", "D", "C")),
+                is(List.of("B", "D", "C", "A")),
+                is(List.of("D", "C", "A", "B")),
+                is(List.of("C", "A", "B", "D")),
+                is(List.of("A", "C", "D", "B")),
+                is(List.of("C", "D", "B", "A")),
+                is(List.of("D", "B", "A", "C")),
+                is(List.of("B", "A", "C", "D"))
+        ));
+    }
+
+    @Test
+    void iterativeDFSShouldReturnSingleElementForSingleNodeGraph() {
+        List<String> result = DFSGraph.iterativeDFS(GraphUtil.convertMapToGraph(Map.of("A", Set.of())));
+        assertThat(result, is(List.of("A")));
+    }
+
+    @Test
+    void iterativeDFSShouldTraverseLinearChain() {
+        // A - B - C
+        Map<String, Set<String>> map = Map.ofEntries(
+                Map.entry("A", Set.of("B")),
+                Map.entry("B", Set.of("A", "C")),
+                Map.entry("C", Set.of("B"))
+        );
+        List<String> result = DFSGraph.iterativeDFS(GraphUtil.convertMapToGraph(map));
+        assertThat(result, anyOf(
+                is(List.of("A", "B", "C")),
+                is(List.of("B", "A", "C")),
+                is(List.of("B", "C", "A")),
+                is(List.of("C", "B", "A"))
+        ));
+    }
+
+    @Test
+    void iterativeDFSShouldTraverseTreeGraph() {
+        //     R
+        //    / \
+        //   A   B
+        //  / \
+        // C   D
+        Map<String, Set<String>> map = Map.ofEntries(
+                Map.entry("R", Set.of("A", "B")),
+                Map.entry("A", Set.of("R", "C", "D")),
+                Map.entry("B", Set.of("R")),
+                Map.entry("C", Set.of("A")),
+                Map.entry("D", Set.of("A"))
+        );
+        List<String> result = DFSGraph.iterativeDFS(GraphUtil.convertMapToGraph(map));
+        assertThat(result, containsInAnyOrder("R", "A", "B", "C", "D"));
+    }
+
+    @Test
+    void iterativeDFSShouldWorkWithIntegerNodes() {
+        Map<Integer, Set<Integer>> map = Map.ofEntries(
+                Map.entry(1, Set.of(2)),
+                Map.entry(2, Set.of(1))
+        );
+        List<Integer> result = DFSGraph.iterativeDFS(GraphUtil.convertMapToGraph(map));
+        assertThat(result, anyOf(is(List.of(1, 2)), is(List.of(2, 1))));
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add 4 tests each to `BFSGraphTest` and `DFSGraphTest` (8 total)
- Single-node graph: verifies traversal terminates and returns `[A]`
- Linear chain (A-B-C): enumerates all valid orderings with `anyOf`
- Tree graph (R→A,B; A→C,D): uses `containsInAnyOrder` since many valid orderings exist due to nondeterministic `Set` iteration
- Integer-typed nodes: validates generics beyond `String`

## Test plan
- [x] Run `mvn test` — all 5 tests in `BFSGraphTest` and all 5 in `DFSGraphTest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)